### PR TITLE
Update documentation for `Value` type alias

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -402,7 +402,7 @@ decodeValue =
   Elm.Kernel.Json.run
 
 
-{-| A JSON value.
+{-| Represents a JavaScript value.
 -}
 type alias Value = Json.Encode.Value
 


### PR DESCRIPTION
It aliases `Json.Encode.Value` therefore it would be prudent to use the same description. See issue at https://github.com/elm-lang/core/issues/957